### PR TITLE
Fix argparse handling in scramble_dml

### DIFF
--- a/scramble_dml.py
+++ b/scramble_dml.py
@@ -92,15 +92,15 @@ logger = logging.getLogger(__name__)
 logger.info("Script started.")
 
 ### Capture Arguments
-file = None
+file_path = None
 
 parser = argparse.ArgumentParser(description='Anonymise and obsfucate DML data.\nReplaces IP Addresses, MAC Addresses, Hostnames')
-parser.add_argument('-f', '--file', dest='file', type=file, required=True, metavar='DML FILE', help='The DML file for this script.\n')
+parser.add_argument('-f', '--file', dest='file_path', type=str, required=True, metavar='DML FILE', help='The DML file for this script.\n')
 
 args = parser.parse_args()
-file = args.file
+file_path = args.file_path
 
-fileExists(file)
+fileExists(file_path)
 
 ipSwaps = []
 macSwaps = []
@@ -126,14 +126,14 @@ genericUsers = [ 'NT AUTHORITY\\SYSTEM',
 newDML = open("scrambled.dml","w")
 usernameFile = open("usernames.log","w")
 
-wc = len(open(file).readlines())
+wc = len(open(file_path).readlines())
 stopgap = wc + 1 # stopgap for testing
 print("No. of lines in file: %i" % wc)
 if float(wc) > 500000:
     print("Warning: This may take a while...")
 
 # Setup Value Swaps
-with open(file, 'r') as f:
+with open(file_path, 'r') as f:
     c = 0
     for line in f.readlines():
         c += 1
@@ -191,7 +191,7 @@ usernameFile.write(str(userSwaps))
 
 print("\n100%")
 # Replace Values
-with open(file, 'r') as f:
+with open(file_path, 'r') as f:
     c = 0
     for line in f.readlines():
         old_line = line


### PR DESCRIPTION
## Summary
- parse the `--file` argument as a string path instead of using an undefined symbol
- open the input file using that path

## Testing
- `python -m py_compile scramble_dml.py`
- `python scramble_dml.py --help`

------
https://chatgpt.com/codex/tasks/task_e_686c494dd7a88326b8e24b70fa43c9fa