### PR TITLE
Fix username capture logic

### DIFF
--- a/scramble_dml.py
+++ b/scramble_dml.py
@@ -173,12 +173,10 @@ with open(file, 'r') as f:
                 fakeHostN = "%s%s-%i" % (hostHash, random.choice(envs), random.randint(1,9))
                 hostSwaps, uniqHosts = substitutes(fakeHostN, hostname, uniqHosts, hostSwaps)
         usernames = findMatch(line, "attribute\sname=\"username\">(.+)<")
-        username = None
-        if username:
-            u1 = username.group(1)
-            u1.replace('"', '')
-            u1.replace("'", "")
-            usernames.append(u1)
+        if usernames:
+            username = usernames[0]
+            username = username.replace('"', '').replace("'", "")
+            usernames = [username]
         for user in usernames:
             if user and user not in genericUsers:
                 if user.lower() == "name":


### PR DESCRIPTION
## Summary
- clean up username capture logic in `scramble_dml.py`

## Testing
- `python3 -m py_compile scramble_dml.py`

------
https://chatgpt.com/codex/tasks/task_e_686c4a617cec8326861ca8a5de48f7f9