### PR TITLE
Fix shebang and fileExists message

### DIFF
--- a/random_generator/generate_dml.py
+++ b/random_generator/generate_dml.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Generate a DML file for use in BMC Discovery for generating Playback data
 #
@@ -55,7 +55,7 @@ def makeSerial(count):
 def fileExists(file):
     exists = os.path.isfile(file)
     if not exists:
-        msg = "Ficonnectionsle '%s' does not exist!" % file
+        msg = "File '%s' does not exist!" % file
         print(msg)
         logger.critical(msg)
         sys.exit(1)


### PR DESCRIPTION
## Summary
- update shebang in generate_dml.py to python3
- correct fileExists error message in generate_dml.py

## Testing
- `python3 -m py_compile dump_dml.py get_dml.py scramble_dml.py random_generator/generate_dml.py`

------
https://chatgpt.com/codex/tasks/task_e_686c4d66d3488326be850b46d610a213